### PR TITLE
fix: set a skin for the Android emulator in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           target: google_apis
           arch: x86_64
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none -skin 1080x2400
           disable-animations: true
           script: ./gradlew connectedCheck --parallel --build-cache
 


### PR DESCRIPTION
Adds the `-skin 1080x2400` option to the emulator startup command. This ensures a consistent screen size for tests running in the CI workflow and aims to eliminate the issue where some elements are not rendered.