### PR TITLE
refactor: improve date of birth validation and error handling

### DIFF
--- a/app/src/androidTest/java/com/android/universe/ui/profileCreation/AddProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/universe/ui/profileCreation/AddProfileScreenTest.kt
@@ -58,16 +58,11 @@ class AddProfileScreenTest {
     // Date of birth
     composeTestRule.onNodeWithTag(AddProfileScreenTestTags.DATE_OF_BIRTH_TEXT).assertIsDisplayed()
     composeTestRule.onNodeWithTag(AddProfileScreenTestTags.DAY_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR_EMPTY).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR_NUMBER).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(AddProfileScreenTestTags.MONTH_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR_EMPTY).assertIsNotDisplayed()
-    composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR_NUMBER)
-        .assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR).assertIsNotDisplayed()
     composeTestRule.onNodeWithTag(AddProfileScreenTestTags.YEAR_FIELD).assertIsDisplayed()
-    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR_EMPTY).assertIsNotDisplayed()
-    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR_NUMBER).assertIsNotDisplayed()
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR).assertIsNotDisplayed()
 
     // Save button
     composeTestRule.onNodeWithTag(AddProfileScreenTestTags.SAVE_BUTTON).assertIsDisplayed()
@@ -173,12 +168,7 @@ class AddProfileScreenTest {
 
     // Assert that the error message is not displayed
     composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR_EMPTY, useUnmergedTree = true)
-        .assertIsNotDisplayed()
-
-    // Assert that the error message is not displayed
-    composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR_NUMBER, useUnmergedTree = true)
+        .onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR, useUnmergedTree = true)
         .assertIsNotDisplayed()
   }
 
@@ -194,12 +184,7 @@ class AddProfileScreenTest {
 
     // Assert that the error message is not displayed
     composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR_EMPTY, useUnmergedTree = true)
-        .assertIsNotDisplayed()
-
-    // Assert that the error message is not displayed
-    composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR_NUMBER, useUnmergedTree = true)
+        .onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR, useUnmergedTree = true)
         .assertIsNotDisplayed()
   }
 
@@ -215,12 +200,7 @@ class AddProfileScreenTest {
 
     // Assert that the error message is not displayed
     composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR_EMPTY, useUnmergedTree = true)
-        .assertIsNotDisplayed()
-
-    // Assert that the error message is not displayed
-    composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR_NUMBER, useUnmergedTree = true)
+        .onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR, useUnmergedTree = true)
         .assertIsNotDisplayed()
   }
 
@@ -276,12 +256,12 @@ class AddProfileScreenTest {
 
     // Assert that the error message is displayed
     composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR_EMPTY, useUnmergedTree = true)
+        .onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR, useUnmergedTree = true)
         .assertExists()
   }
 
   @Test
-  fun showsDayErrorWhenNotNumber() {
+  fun showsDayEmptyErrorWhenNonDigitsInput() {
     val text = "hello"
     // Focus the username field
     composeTestRule.onNodeWithTag(AddProfileScreenTestTags.DAY_FIELD).performTextInput(text)
@@ -291,7 +271,23 @@ class AddProfileScreenTest {
 
     // Assert that the error message is displayed
     composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR_NUMBER, useUnmergedTree = true)
+        .onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR, useUnmergedTree = true)
+        .assertExists()
+        .assertTextEquals("Day cannot be empty")
+  }
+
+  @Test
+  fun showsDayErrorWhenErroneousInput() {
+    val text = "32"
+    // Focus the username field
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.DAY_FIELD).performTextInput(text)
+
+    // Move focus away to trigger validation
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.DAY_FIELD).performClick()
+
+    // Assert that the error message is displayed
+    composeTestRule
+        .onNodeWithTag(AddProfileScreenTestTags.DAY_ERROR, useUnmergedTree = true)
         .assertExists()
   }
 
@@ -305,12 +301,27 @@ class AddProfileScreenTest {
 
     // Assert that the error message is displayed
     composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR_EMPTY, useUnmergedTree = true)
+        .onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR, useUnmergedTree = true)
         .assertExists()
   }
 
   @Test
-  fun showsMonthErrorWhenNotNumber() {
+  fun showsMonthErrorWhenErroneousMonth() {
+    val text = "13"
+    // Focus the username field
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.MONTH_FIELD).performTextInput(text)
+
+    // Move focus away to trigger validation
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.MONTH_FIELD).performClick()
+
+    // Assert that the error message is displayed
+    composeTestRule
+        .onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR, useUnmergedTree = true)
+        .assertExists()
+  }
+
+  @Test
+  fun showsMonthEmptyErrorWhenNonDigitsInput() {
     val text = "hello"
     // Focus the username field
     composeTestRule.onNodeWithTag(AddProfileScreenTestTags.MONTH_FIELD).performTextInput(text)
@@ -320,8 +331,9 @@ class AddProfileScreenTest {
 
     // Assert that the error message is displayed
     composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR_NUMBER, useUnmergedTree = true)
+        .onNodeWithTag(AddProfileScreenTestTags.MONTH_ERROR, useUnmergedTree = true)
         .assertExists()
+        .assertTextEquals("Month cannot be empty")
   }
 
   @Test
@@ -334,12 +346,12 @@ class AddProfileScreenTest {
 
     // Assert that the error message is displayed
     composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR_EMPTY, useUnmergedTree = true)
+        .onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR, useUnmergedTree = true)
         .assertExists()
   }
 
   @Test
-  fun showsYearErrorWhenNotNumber() {
+  fun showsYearEmptyErrorWhenNonDigitsInput() {
     val text = "hello"
     // Focus the username field
     composeTestRule.onNodeWithTag(AddProfileScreenTestTags.YEAR_FIELD).performTextInput(text)
@@ -349,7 +361,38 @@ class AddProfileScreenTest {
 
     // Assert that the error message is displayed
     composeTestRule
-        .onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR_NUMBER, useUnmergedTree = true)
+        .onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR, useUnmergedTree = true)
+        .assertExists()
+        .assertTextEquals("Year cannot be empty")
+  }
+
+  @Test
+  fun showsYearErrorWhenInvalidYear1() {
+    val text = "1600"
+    // Focus the username field
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.YEAR_FIELD).performTextInput(text)
+
+    // Move focus away to trigger validation
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.YEAR_FIELD).performClick()
+
+    // Assert that the error message is displayed
+    composeTestRule
+        .onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR, useUnmergedTree = true)
+        .assertExists()
+  }
+
+  @Test
+  fun showsYearErrorWhenInvalidYear2() {
+    val text = "8000"
+    // Focus the username field
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.YEAR_FIELD).performTextInput(text)
+
+    // Move focus away to trigger validation
+    composeTestRule.onNodeWithTag(AddProfileScreenTestTags.YEAR_FIELD).performClick()
+
+    // Assert that the error message is displayed
+    composeTestRule
+        .onNodeWithTag(AddProfileScreenTestTags.YEAR_ERROR, useUnmergedTree = true)
         .assertExists()
   }
 

--- a/app/src/main/java/com/android/universe/ui/profileCreation/AddProfileScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/profileCreation/AddProfileScreen.kt
@@ -70,18 +70,15 @@ object AddProfileScreenTestTags {
 
   // Day
   const val DAY_FIELD = "day_field"
-  const val DAY_ERROR_EMPTY = "day_error_empty"
-  const val DAY_ERROR_NUMBER = "day_error_number"
+  const val DAY_ERROR = "day_error"
 
   // Month
   const val MONTH_FIELD = "month_field"
-  const val MONTH_ERROR_EMPTY = "month_error_empty"
-  const val MONTH_ERROR_NUMBER = "month_error_number"
+  const val MONTH_ERROR = "month_error"
 
   // Year
   const val YEAR_FIELD = "year_field"
-  const val YEAR_ERROR_EMPTY = "year_error_empty"
-  const val YEAR_ERROR_NUMBER = "year_error_number"
+  const val YEAR_ERROR = "year_error"
 
   // Save button
   const val SAVE_BUTTON = "save_button"
@@ -319,18 +316,12 @@ fun AddProfileScreen(addProfileViewModel: AddProfileViewModel = viewModel()) {
                                   },
                           shape = RoundedCornerShape(12.dp),
                           singleLine = true)
-                      if (hasTouchedDay && profileUIState.day.isBlank()) {
+                      if (hasTouchedDay && profileUIState.dayError != null) {
                         Text(
-                            text = "Day cannot be empty",
+                            text = profileUIState.dayError!!,
                             color = Color.Red,
                             style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.testTag(AddProfileScreenTestTags.DAY_ERROR_EMPTY))
-                      } else if (hasTouchedDay && profileUIState.day.toIntOrNull() == null) {
-                        Text(
-                            text = "Day need to be a number",
-                            color = Color.Red,
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.testTag(AddProfileScreenTestTags.DAY_ERROR_NUMBER))
+                            modifier = Modifier.testTag(AddProfileScreenTestTags.DAY_ERROR))
                       }
                     }
 
@@ -353,19 +344,12 @@ fun AddProfileScreen(addProfileViewModel: AddProfileViewModel = viewModel()) {
                                   },
                           shape = RoundedCornerShape(12.dp),
                           singleLine = true)
-                      if (hasTouchedMonth && profileUIState.month.isBlank()) {
+                      if (hasTouchedMonth && profileUIState.monthError != null) {
                         Text(
-                            text = "Month cannot be empty",
+                            text = profileUIState.monthError!!,
                             color = Color.Red,
                             style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.testTag(AddProfileScreenTestTags.MONTH_ERROR_EMPTY))
-                      } else if (hasTouchedMonth && profileUIState.month.toIntOrNull() == null) {
-                        Text(
-                            text = "Month need to be a number",
-                            color = Color.Red,
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier =
-                                Modifier.testTag(AddProfileScreenTestTags.MONTH_ERROR_NUMBER))
+                            modifier = Modifier.testTag(AddProfileScreenTestTags.MONTH_ERROR))
                       }
                     }
 
@@ -388,18 +372,12 @@ fun AddProfileScreen(addProfileViewModel: AddProfileViewModel = viewModel()) {
                                   },
                           shape = RoundedCornerShape(12.dp),
                           singleLine = true)
-                      if (hasTouchedYear && profileUIState.year.isBlank()) {
+                      if (hasTouchedYear && profileUIState.yearError != null) {
                         Text(
-                            text = "Year cannot be empty",
+                            text = profileUIState.yearError!!,
                             color = Color.Red,
                             style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.testTag(AddProfileScreenTestTags.YEAR_ERROR_EMPTY))
-                      } else if (hasTouchedYear && profileUIState.year.toIntOrNull() == null) {
-                        Text(
-                            text = "Year need to be a number",
-                            color = Color.Red,
-                            style = MaterialTheme.typography.bodySmall,
-                            modifier = Modifier.testTag(AddProfileScreenTestTags.YEAR_ERROR_NUMBER))
+                            modifier = Modifier.testTag(AddProfileScreenTestTags.YEAR_ERROR))
                       }
                     }
               }
@@ -414,15 +392,13 @@ fun AddProfileScreen(addProfileViewModel: AddProfileViewModel = viewModel()) {
                       .fillMaxWidth()
                       .testTag(AddProfileScreenTestTags.SAVE_BUTTON),
               enabled =
-                  profileUIState.username.isNotBlank() &&
-                      profileUIState.firstName.isNotBlank() &&
-                      profileUIState.lastName.isNotBlank() &&
-                      profileUIState.day.isNotBlank() &&
-                      profileUIState.day.toIntOrNull() != null &&
-                      profileUIState.month.isNotBlank() &&
-                      profileUIState.month.toIntOrNull() != null &&
-                      profileUIState.year.isNotBlank() &&
-                      profileUIState.year.toIntOrNull() != null,
+                  profileUIState.usernameError == null &&
+                      profileUIState.firstNameError == null &&
+                      profileUIState.lastNameError == null &&
+                      profileUIState.descriptionError == null &&
+                      profileUIState.dayError == null &&
+                      profileUIState.monthError == null &&
+                      profileUIState.yearError == null,
               colors =
                   ButtonDefaults.buttonColors(
                       containerColor = Color.Black, contentColor = Color.White),

--- a/app/src/test/java/com/android/universe/ui/profileCreation/AddProfileViewModelTest.kt
+++ b/app/src/test/java/com/android/universe/ui/profileCreation/AddProfileViewModelTest.kt
@@ -438,29 +438,7 @@ class AddProfileViewModelTest {
   }
 
   @Test
-  fun addProfileInvalidDate5() = runTest {
-    val repository = FakeUserRepository()
-    val testDispatcher = StandardTestDispatcher(testScheduler)
-    val viewModel = AddProfileViewModel(repository, testDispatcher)
-
-    viewModel.setUsername("john_doe")
-    viewModel.setFirstName("John")
-    viewModel.setLastName("Doe")
-    viewModel.setCountry("United States")
-    viewModel.setDay("-2")
-    viewModel.setMonth("1")
-    viewModel.setYear("2025")
-
-    viewModel.addProfile()
-    advanceUntilIdle()
-
-    val users = repository.getAllUsers()
-    assertEquals(0, users.size)
-    assertEquals("Invalid date", viewModel.uiState.value.errorMsg)
-  }
-
-  @Test
-  fun addProfileInvalidDate6() = runTest {
+  fun addProfileInvalidDate4() = runTest {
     val repository = FakeUserRepository()
     val testDispatcher = StandardTestDispatcher(testScheduler)
     val viewModel = AddProfileViewModel(repository, testDispatcher)
@@ -470,7 +448,7 @@ class AddProfileViewModelTest {
     viewModel.setLastName("Doe")
     viewModel.setCountry("United States")
     viewModel.setDay("12")
-    viewModel.setMonth("-1")
+    viewModel.setMonth("11")
     viewModel.setYear("2025")
 
     viewModel.addProfile()
@@ -478,7 +456,7 @@ class AddProfileViewModelTest {
 
     val users = repository.getAllUsers()
     assertEquals(0, users.size)
-    assertEquals("Invalid date", viewModel.uiState.value.errorMsg)
+    assertEquals("At least 13 years old required", viewModel.uiState.value.errorMsg)
   }
 
   @Test


### PR DESCRIPTION
Refactors the date of birth input validation in the `AddProfileViewModel` and `AddProfileScreen`.

Specific changes:
-   Adds an age check to ensure users are at least 13 years old.
-   Introduces real-time validation for day, month, and year fields, providing specific error messages for blank, non-numeric, or out-of-range inputs.
-   Filters out non-digit characters from date fields automatically.
-   Updates `AddProfileScreen` to display a single, more descriptive error message for each date field.
-   Enables the save button based on the absence of any validation errors, rather than checking if fields are simply not blank.
-   Removes an obsolete test case (`addProfileInvalidDate5`) and updates another (`addProfileInvalidDate4`) to check the new age requirement.
-   Adds and refactors UI tests in `AddProfileScreenTest` to cover the new validation logic and error messages.

closes #33
closes #40 