### PR TITLE
feat: Correct profile screen based on Addprofile restrictions

### DIFF
--- a/app/src/androidTest/java/com/android/universe/ui/profile/UserProfileScreenTest.kt
+++ b/app/src/androidTest/java/com/android/universe/ui/profile/UserProfileScreenTest.kt
@@ -71,7 +71,7 @@ class UserProfileScreenTest {
   }
 
   @Test
-  fun tooManyTagsShowsPartialContent() = runTest {
+  fun tooManyTagsImpliesScrollable() = runTest {
     val manyTags = tagsInterest.union(tagsCanton).toSet()
     val profile =
         UserProfile(
@@ -88,19 +88,7 @@ class UserProfileScreenTest {
     composeTestRule.setContent { UserProfileScreen(username = profile.username) }
 
     composeTestRule.waitForIdle()
-
-    val unDisplayedTag =
-        try {
-          for (i in 0 until manyTags.size) {
-            composeTestRule
-                .onNodeWithTag(UserProfileScreenTestTags.getTagTestTag(i))
-                .assertIsDisplayed()
-          }
-          false
-        } catch (assertionError: AssertionError) {
-          true
-        }
-    assertTrue(unDisplayedTag)
+    composeTestRule.onNodeWithTag(UserProfileScreenTestTags.TAGLIST).assert(hasScrollAction())
 
     UserRepositoryProvider.repository.deleteUser(profile.username)
   }

--- a/app/src/main/java/com/android/universe/ui/profile/UserProfileScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/profile/UserProfileScreen.kt
@@ -33,6 +33,7 @@ object UserProfileScreenTestTags {
   const val AGE = "userProfileAge"
   const val COUNTRY = "userProfileCountry"
   const val DESCRIPTION = "userProfileDescription"
+  const val TAGLIST = "userProfileTagList"
 
   fun getTagTestTag(index: Int): String {
     return "userProfileTag$index"
@@ -147,7 +148,10 @@ fun UserProfileScreen(
                           .background(Color.LightGray.copy(alpha = 0.3f)),
                   contentAlignment = Alignment.Center) {
                     FlowRow(
-                        modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
+                        modifier =
+                            Modifier.testTag(UserProfileScreenTestTags.TAGLIST)
+                                .fillMaxWidth()
+                                .verticalScroll(rememberScrollState()),
                         horizontalArrangement = Arrangement.SpaceAround,
                         verticalArrangement = Arrangement.spacedBy(4.dp)) {
                           userUIState.userProfile.tags.toList().forEachIndexed { index, tag ->


### PR DESCRIPTION
Adapts data fields based on the new restrictions of user inputs and corrects layout

- The names are now in column instead of a row, more accurately resembling the figma
- The names, age and country fontsizes are now fixed in accord with the restrictions
- The tags are now a flowrow for easier managing and cleaner design
- Fixed some broken tests to adapt for the new tags layout

closes #50 

Commits inside PR:
feat: refactor user profile tags display
feat: add unique test tags for user interests
feat: add scroll test for tags in user profile