### PR TITLE
feat: add test data for events and users

### DIFF
--- a/app/src/main/java/com/android/universe/commonTest/EventTestData.kt
+++ b/app/src/main/java/com/android/universe/commonTest/EventTestData.kt
@@ -1,0 +1,79 @@
+package com.android.universe.commonTest
+
+import com.android.universe.model.Tag
+import com.android.universe.model.event.Event
+import com.android.universe.model.location.Location
+import java.time.LocalDateTime
+
+object EventTestData {
+  private val Alice = UserTestData.NullDescription
+  private val Bob = UserTestData.ManyTagsUser
+
+  private val DummyLocation = Location(latitude = 46.5196535, longitude = 6.6322734)
+
+  private val DummyDate = LocalDateTime.of(2025, 10, 15, 7, 30)
+  val FullDescriptionEvent =
+      Event(
+          id = "event-001",
+          title = "Morning Run at the Lake",
+          description = "Join us for a casual 5km run around the lake followed by coffee.",
+          date = DummyDate,
+          tags = setOf(Tag.SCULPTURE, Tag.COUNTRY),
+          participants = setOf(Alice, Bob),
+          creator = Alice,
+          location = DummyLocation)
+
+  val EmptyDescriptionEvent =
+      Event(
+          id = "event-002",
+          title = "Morning Run at the Lake",
+          description = "",
+          date = DummyDate,
+          tags = setOf(Tag.SCULPTURE, Tag.COUNTRY),
+          participants = setOf(Alice, Bob),
+          creator = Alice,
+          location = DummyLocation)
+  val NullDescriptionEvent =
+      Event(
+          id = "event-003",
+          title = "Morning Run at the Lake",
+          description = null,
+          date = DummyDate,
+          tags = setOf(Tag.SCULPTURE, Tag.COUNTRY),
+          participants = setOf(Alice, Bob),
+          creator = Alice,
+          location = DummyLocation)
+
+  val NoParticipantEvent =
+      Event(
+          id = "event-004",
+          title = "Morning Run at the Lake",
+          description = null,
+          date = DummyDate,
+          tags = setOf(Tag.SCULPTURE, Tag.COUNTRY),
+          participants = emptySet(),
+          creator = Alice,
+          location = DummyLocation)
+
+  val NoTagsEvent =
+      Event(
+          id = "event-005",
+          title = "Morning Run at the Lake",
+          description = null,
+          date = DummyDate,
+          tags = emptySet(),
+          participants = emptySet(),
+          creator = Alice,
+          location = DummyLocation)
+
+  val SomeTagsEvent =
+      Event(
+          id = "event-006",
+          title = "Morning Run at the Lake",
+          description = null,
+          date = DummyDate,
+          tags = UserTestData.someTags,
+          participants = emptySet(),
+          creator = Alice,
+          location = DummyLocation)
+}

--- a/app/src/main/java/com/android/universe/commonTest/UserTestData.kt
+++ b/app/src/main/java/com/android/universe/commonTest/UserTestData.kt
@@ -1,0 +1,81 @@
+package com.android.universe.commonTest
+
+import com.android.universe.model.Tag
+import com.android.universe.model.user.UserProfile
+import java.time.LocalDate
+
+object UserTestData {
+  val noTag = emptySet<Tag>()
+  val singleTag = setOf(Tag.METAL)
+  val twoTags = setOf(Tag.ROCK, Tag.POP)
+  val someTags = setOf(Tag.ROCK, Tag.POP, Tag.METAL, Tag.JAZZ, Tag.BLUES, Tag.COUNTRY)
+  val manyTags =
+      (Tag.getTagsForCategory(Tag.Category.INTEREST) + Tag.getTagsForCategory(Tag.Category.CANTON))
+          .toSet()
+
+  private val DummyDate = LocalDate.of(2000, 8, 11)
+
+  val FullDescription =
+      UserProfile(
+          uid = "20",
+          username = "desc",
+          firstName = "Desc",
+          lastName = "Ription",
+          country = "FR",
+          description = "Maxime the goat",
+          dateOfBirth = DummyDate,
+          tags = noTag)
+
+  val EmptyDescription =
+      UserProfile(
+          uid = "20",
+          username = "desc",
+          firstName = "Desc",
+          lastName = "Ription",
+          country = "FR",
+          description = "",
+          dateOfBirth = DummyDate,
+          tags = noTag)
+
+  val NullDescription =
+      UserProfile(
+          uid = "21",
+          username = "desc",
+          firstName = "Desc",
+          lastName = "Ription",
+          country = "FR",
+          description = null,
+          dateOfBirth = DummyDate,
+          tags = noTag)
+  val ManyTagsUser =
+      UserProfile(
+          uid = "22",
+          username = "desc",
+          firstName = "Desc",
+          lastName = "Ription",
+          country = "FR",
+          description = null,
+          dateOfBirth = DummyDate,
+          tags = manyTags)
+  val SomeTagsUser =
+      UserProfile(
+          uid = "23",
+          username = "desc",
+          firstName = "Desc",
+          lastName = "Ription",
+          country = "FR",
+          description = null,
+          dateOfBirth = DummyDate,
+          tags = someTags)
+
+  val NoTagsUser =
+      UserProfile(
+          uid = "23",
+          username = "desc",
+          firstName = "Desc",
+          lastName = "Ription",
+          country = "FR",
+          description = null,
+          dateOfBirth = DummyDate,
+          tags = noTag)
+}


### PR DESCRIPTION
Introduces test data for `Event` and `UserProfile` models to be used in common tests.

- `EventTestData.kt`: Provides various `Event` instances, covering cases like full descriptions, empty/null descriptions, no participants, and different tag configurations.
- `UserTestData.kt`: Provides `UserProfile` instances with varying descriptions and tag sets, from no tags to many.