### PR TITLE
fix: remove explicit white background from profile screen

### DIFF
--- a/app/src/main/java/com/android/universe/ui/profile/UserProfileScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/profile/UserProfileScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
@@ -155,7 +154,7 @@ fun UserProfileScreen(
   Scaffold(
       modifier = Modifier.testTag(NavigationTestTags.PROFILE_SCREEN),
       bottomBar = { NavigationBottomMenu(Tab.Profile, onTabSelected) }) { padding ->
-        Box(modifier = Modifier.fillMaxSize().padding(padding).background(Color.White)) {
+        Box(modifier = Modifier.fillMaxSize().padding(padding)) {
           // Box that contains the decoration background.
           Box(modifier = Modifier.fillMaxWidth()) { CurvedTopHeader() }
           Column(


### PR DESCRIPTION
### Description:
This pull request removes the explicit background color declaration in the UserProfileScreen. It fixes a bug where, in dark mode, white elements were displayed on a white background, making the content invisible to the user.

Fix #180 

Image of the UserProfileScreen in dark mode with the fix:

<img width="420" height="879" alt="image" src="https://github.com/user-attachments/assets/1c2b30b6-c09e-44f0-91cf-1c6a8747f4fa" />
