### PR TITLE
feat: make event creation background transparent

### DIFF
--- a/app/src/main/java/com/android/universe/ui/eventCreation/EventCreationScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/eventCreation/EventCreationScreen.kt
@@ -172,6 +172,7 @@ fun EventCreationScreen(
       else eventCreationViewModel.formatTime(uiState.value.time)
   val showTime = remember { mutableStateOf(false) }
   Scaffold(
+      containerColor = Color.Transparent,
       content = { paddingValues ->
         Column(modifier = Modifier.padding(paddingValues)) {
           val context = LocalContext.current


### PR DESCRIPTION
### Description:
This pull request fixes a bug encountered in the EventCreationScreen. On this screen, the Scaffold was missing `containerColor = Color.Transparent`, which caused the transparent background with the map and the blur effect not to display.

This pull request adds `containerColor = Color.Transparent` to the Scaffold in the EventCreationScreen

Fix #219 

Image of the screen after the fix:

<img width="661" height="1378" alt="image" src="https://github.com/user-attachments/assets/b45735c5-487a-4c52-be2e-8d38c5da2640" />
