### PR TITLE
feat: clear tags when leaving event creation screen

### DIFF
--- a/app/src/main/java/com/android/universe/ui/eventCreation/EventCreationScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/eventCreation/EventCreationScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -160,6 +161,8 @@ fun EventCreationScreen(
     onSave: () -> Unit = {},
     onAddTag: () -> Unit = {}
 ) {
+  // If the user leave the screen we clear all the tags in the tagRepositoryProvider.
+  DisposableEffect(Unit) { onDispose { eventCreationViewModel.clearTags() } }
   val uiState = eventCreationViewModel.uiStateEventCreation.collectAsState()
   val tags = eventCreationViewModel.eventTags.collectAsState()
   val eventImage = uiState.value.eventPicture

--- a/app/src/main/java/com/android/universe/ui/eventCreation/EventCreationViewModel.kt
+++ b/app/src/main/java/com/android/universe/ui/eventCreation/EventCreationViewModel.kt
@@ -323,4 +323,9 @@ class EventCreationViewModel(
       }
     }
   }
+
+  /** Clear all the tags of the tagRepositoryProvider. */
+  fun clearTags() {
+    viewModelScope.launch { tagRepository.deleteAllTags() }
+  }
 }


### PR DESCRIPTION
### Description:
This pull request fixes a bug encountered in the EventCreationScreen related to the flow of selected tags.
Steps that create the problem:
- Open EventCreationScreen
- Navigate to SelectTagScreen and select some tags
- Return to EventCreationScreen -> tags correctly appear as selected
- Press Back -> user returns to the map screen
- Navigate again to EventCreationScreen -> previously selected tags are still selected

The issue was caused by the tagRepositoryProvider not being cleared when pressing the phone's back button.

fixes #220 
