### PR TITLE
refactor: make TagRow fill max width

### DIFF
--- a/app/src/main/java/com/android/universe/ui/event/EventScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/event/EventScreen.kt
@@ -112,6 +112,7 @@ fun EventScreen(
               Box(modifier = Modifier.fillMaxWidth()) {
                 TagRow(
                     allCats,
+                    modifierBox = Modifier.fillMaxWidth(),
                     heightTag = CategoryItemDefaults.HEIGHT_CAT,
                     widthTag = CategoryItemDefaults.WIDTH_CAT,
                     isSelected = { cat -> categories.contains(cat.category) },

--- a/app/src/main/java/com/android/universe/ui/map/MapScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/map/MapScreen.kt
@@ -226,7 +226,7 @@ fun MapScreen(
 
             TagRow(
                 categoryList,
-                modifierBox = Modifier.offset(y = topOffset),
+                modifierBox = Modifier.fillMaxWidth().offset(y = topOffset),
                 heightTag = CategoryItemDefaults.HEIGHT_CAT,
                 widthTag = CategoryItemDefaults.WIDTH_CAT,
                 isSelected = { cat -> categories.contains(cat.category) },

--- a/app/src/main/java/com/android/universe/ui/searchProfile/SearchProfileScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/searchProfile/SearchProfileScreen.kt
@@ -198,6 +198,7 @@ fun SearchHeader(
 
     TagRow(
         allCats,
+        modifierBox = Modifier.fillMaxWidth(),
         heightTag = CategoryItemDefaults.HEIGHT_CAT,
         widthTag = CategoryItemDefaults.WIDTH_CAT,
         isSelected = { cat -> categories.contains(cat.category) },


### PR DESCRIPTION
Applies the `fillMaxWidth` modifier to the `TagRow` composable in the `MapScreen`, `SearchProfileScreen`, and `EventScreen`. This ensures the tag container spans the entire available width.

description generated by AI