### PR TITLE
Fix/eventcreationscreen error shape and title

### DIFF
--- a/app/src/main/java/com/android/universe/ui/eventCreation/EventCreationScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/eventCreation/EventCreationScreen.kt
@@ -81,7 +81,6 @@ object EventCreationTestTags {
 }
 
 object EventCreationDefaults {
-  val eventPictureBoxHeight = 270.dp
   val eventBoxCornerRadius = 24.dp
   val titleFontSize = 32.sp
   const val SET_LOCATION_BUTTON_HEIGHT = 40f


### PR DESCRIPTION
### Description:
This pull request fixes one bug in the EventCreationScreen.

- The first bug was that the shape of the LiquidBox was not adapted to its purpose, and on different devices the box extended beyond the bottom of the screen.
Basically this line have been modified: `shape = RoundedCornerShape(EventCreationDefaults.eventBoxCornerRadius` to
`shape = BottomSheetDefaults.ExpandedShape`

Fix #268 