### PR TITLE
refactor: set initial email validation state to neutral

### DIFF
--- a/app/src/main/java/com/android/universe/ui/signIn/SignInViewModel.kt
+++ b/app/src/main/java/com/android/universe/ui/signIn/SignInViewModel.kt
@@ -75,7 +75,7 @@ data class SignInUIState(
     val user: FirebaseUser? = null,
     val signedOut: Boolean = false,
     val email: String = "",
-    val emailErrorMsg: ValidationState = ValidationState.Valid,
+    val emailErrorMsg: ValidationState = ValidationState.Neutral,
     val password: String = "",
     val passwordErrorMsg: ValidationState = ValidationState.Neutral,
     val onboardingState: OnboardingState = OnboardingState.WELCOME,


### PR DESCRIPTION
### Description:
This pull request fixes a bug in the SignInScreen where, when the user has to enter their email, the text field is already marked as valid and displayed in green. This pull request changes this behavior so that, at the start, the text field is neutral. After the user enters an email, it updates its validity state based on the input.


https://github.com/user-attachments/assets/27c3ae8d-e957-4ec7-8f02-4137eea66be7

