### PR TITLE
Refactor: reorder bottombar tabs

### DIFF
--- a/app/src/main/java/com/android/universe/ui/navigation/NavigationBottomMenu.kt
+++ b/app/src/main/java/com/android/universe/ui/navigation/NavigationBottomMenu.kt
@@ -61,8 +61,8 @@ sealed class Tab(
 val tabs =
     listOf(
         Tab.Chat,
-        Tab.Map,
         Tab.Event,
+        Tab.Map,
         Tab.Profile,
         Tab.Community,
     )


### PR DESCRIPTION
This PR reorders the bottom bar to:

<img width="313" height="71" alt="Screenshot 2025-12-15 at 18 21 01" src="https://github.com/user-attachments/assets/17035e38-982d-456b-b25d-687940d2744b" />

Closes https://github.com/SwEnt-Universe/UniVERSE/issues/352
