### PR TITLE
fix: Set onboarding state when editing an event

### DIFF
--- a/app/src/main/java/com/android/universe/ui/eventCreation/EventCreationViewModel.kt
+++ b/app/src/main/java/com/android/universe/ui/eventCreation/EventCreationViewModel.kt
@@ -220,7 +220,12 @@ class EventCreationViewModel(
                 description = event.description ?: "",
                 date = eventDate,
                 time = formatTime(eventTime),
-                isPrivate = event.isPrivate)
+                isPrivate = event.isPrivate,
+                onboardingState =
+                    mutableMapOf(
+                        OnboardingState.ENTER_EVENT_TITLE to true,
+                        OnboardingState.ENTER_DESCRIPTION to (event.description != null),
+                        OnboardingState.ENTER_TIME to true))
       }
     }
   }


### PR DESCRIPTION
Fix a bug in the `EventEditionScreen`: when entering the screen, the text fields that already contain text should have their `ValidState` set to Valid instead of Neutral. This pull request fixes this by updating the onboardingState of the uiState when the event parameters are loaded.