### PR TITLE
Replace creator's name with creator id

### DIFF
--- a/app/src/main/java/com/android/universe/ui/event/EventScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/event/EventScreen.kt
@@ -151,7 +151,7 @@ fun EventScreen(
                           onChatNavigate = onChatNavigate,
                           onCardClick = onCardClick,
                           onEditButtonClick = onEditButtonClick,
-                          isUserOwner = event.creatorId == viewModel.storedUid)
+                          isUserOwner = event.creator == viewModel.storedUid)
                     }
                     item {
                       Spacer(Modifier.height(height = paddingValues.calculateBottomPadding()))

--- a/app/src/main/java/com/android/universe/ui/event/EventViewModel.kt
+++ b/app/src/main/java/com/android/universe/ui/event/EventViewModel.kt
@@ -8,22 +8,17 @@ import com.android.universe.model.event.EventRepository
 import com.android.universe.model.event.EventRepositoryProvider
 import com.android.universe.model.location.Location
 import com.android.universe.model.tag.Tag
-import com.android.universe.model.user.UserProfile
-import com.android.universe.model.user.UserReactiveRepository
-import com.android.universe.model.user.UserReactiveRepositoryProvider
 import com.android.universe.model.user.UserRepository
 import com.android.universe.model.user.UserRepositoryProvider
 import com.android.universe.ui.search.SearchEngine
 import com.android.universe.ui.search.SearchEngine.categoryCoverageComparator
 import java.time.LocalDateTime
 import kotlin.coroutines.cancellation.CancellationException
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -36,7 +31,6 @@ import kotlinx.coroutines.launch
  * @property date The formatted date of the event.
  * @property tags A list of tags associated with the event.
  * @property creator The name of the event creator.
- * @property creatorId The unique identifier of the event creator.
  * @property participants The number of participants in the event.
  * @property location The location of the event.
  * @param isPrivate Whether the event is private.
@@ -52,7 +46,6 @@ data class EventUIState(
     val date: LocalDateTime = LocalDateTime.now(),
     val tags: List<Tag> = emptyList(),
     val creator: String = "",
-    val creatorId: String = "",
     val participants: Int = 0,
     val location: Location = Location(0.0, 0.0),
     val isPrivate: Boolean = false,
@@ -65,54 +58,8 @@ data class EventUIState(
 data class UiState(val errormsg: String? = null)
 
 /**
- * [EventViewModel] orchestrates the retrieval and transformation of event and user data into
- * reactive, UI-friendly state for Compose or other reactive consumers.
- *
- * ## Overview
- * This ViewModel bridges the Firestore data layer (via [EventRepository] and
- * [UserReactiveRepository]) and the UI layer by exposing a [StateFlow] of [EventUIState] items.
- * Each [EventUIState] contains event details plus the up-to-date name of its creator.
- *
- * The ViewModel is designed to:
- * - Fetch all events from Firestore once (via [EventRepository]).
- * - Subscribe to **real-time updates** of each event creator's user profile (via
- *   [UserReactiveRepository]).
- * - Merge both streams to expose a single, continuously updated state for the UI.
- *
- * ## Reactive pipeline
- * 1. Events are loaded from [EventRepository].
- * 2. The distinct set of creator UIDs is extracted from those events.
- * 3. For each UID, [UserReactiveRepository.getUserFlow] is called to get a *shared* [Flow] that
- *    emits a [UserProfile] whenever that user's Firestore document changes.
- * 4. All creator flows are combined via [combine], producing a map of `uid → UserProfile`.
- * 5. For each event, the matching [UserProfile] is used to create an [EventUIState].
- * 6. The final list of [EventUIState] is exposed as a [StateFlow] through [eventsState].
- *
- * ### Result
- * - **Live updates**: If a user changes their first or last name, all events created by them
- *   automatically recompose in the UI — no manual refresh needed.
- * - **Minimal Firestore reads**: Each distinct user has **one shared snapshot listener** regardless
- *   of how many events or UI components depend on it.
- * - **Offline resilience**: Firestore's local cache ensures that users’ data is available even
- *   without network connectivity.
- *
- * ## Design rationale
- * - Uses Kotlin [Flow] and [combine] for reactive data merging.
- * - Uses [StateFlow] to provide replayable, observable state to Jetpack Compose.
- * - Separates concerns cleanly:
- *     - [EventRepository] handles event documents.
- *     - [UserReactiveRepository] handles live user documents.
- *     - [EventViewModel] merges and formats them for UI.
- *
- * ## Threading & lifecycle
- * - All Firestore listeners and Flow operations run in [viewModelScope], which is tied to the
- *   ViewModel lifecycle. When the ViewModel is cleared, collection stops automatically.
- * - No manual listener cleanup is needed here; it is handled by [UserReactiveRepository].
- *
- * ## Fallback mode
- * If [UserReactiveRepository] is unavailable (e.g., dependency injection disabled or running in
- * offline test mode), the ViewModel falls back to a static fetch via [UserRepository], ensuring
- * that event display still works without real-time updates.
+ * [EventViewModel] orchestrates the retrieval and transformation of event into reactive,
+ * UI-friendly state for Compose or other reactive consumers.
  *
  * ## Example usage (Compose)
  *
@@ -129,13 +76,9 @@ data class UiState(val errormsg: String? = null)
  * ```
  *
  * @property eventRepository Source of event documents (Firestore).
- * @property userReactiveRepository Reactive Firestore listener source for user profiles.
- * @property userRepository Non-reactive fallback for one-time user fetches.
  */
 class EventViewModel(
     private val eventRepository: EventRepository = EventRepositoryProvider.repository,
-    private val userReactiveRepository: UserReactiveRepository? =
-        UserReactiveRepositoryProvider.repository,
     private val userRepository: UserRepository = UserRepositoryProvider.repository,
 ) : ViewModel() {
 
@@ -155,20 +98,6 @@ class EventViewModel(
 
   /**
    * Loads all events and transforms them into [EventUIState]s.
-   *
-   * If a [UserReactiveRepository] is available, it will:
-   * - Subscribe to a [Flow] of each creator’s user document in Firestore.
-   * - Combine all user flows into one reactive stream.
-   * - Automatically re-emit the event list whenever any user data changes.
-   *
-   * Otherwise (e.g., in offline or test environments), it will:
-   * - Fetch user data once via [UserRepository.getUser].
-   * - Produce static, non-reactive UI state.
-   *
-   * ### Firestore efficiency
-   * - Only **one Firestore listener** is maintained per unique creator UID.
-   * - Each listener performs **one initial read** and **one read per update**, reducing cost
-   *   compared to polling or repeated `.get()` calls.
    *
    * ### Output
    * Emits a list of [EventUIState]s through [eventsState], sorted and ready for display.
@@ -190,44 +119,19 @@ class EventViewModel(
 
       val now = LocalDateTime.now()
       val events =
-          eventRepository.getAllEvents(storedUid, following).filter { event ->
-            event.date.isAfter(now) || event.date.isEqual(now)
+          eventRepository.getAllEvents(storedUid, following).filter {
+            it.date.isAfter(now) || it.date.isEqual(now)
           }
+
       localList = events
 
-      if (userReactiveRepository != null) {
-        // Convert list of creators to distinct set
-        val distinctCreators = events.map { it.creator }.distinct()
-
-        // Combine all event flows
-        combine(
-                distinctCreators.map { uid ->
-                  userReactiveRepository.getUserFlow(uid).map { uid to it }
-                }) { userPairs ->
-                  val usersMap = userPairs.toMap()
-                  events.mapIndexed { index, event ->
-                    val user = usersMap[event.creator]
-                    event.toUIState(
-                        user,
-                        creatorId = event.creator,
-                        index = index,
-                        joined = event.participants.contains(storedUid),
-                        isPrivate = event.isPrivate)
-                  }
-                }
-            .collect { uiStates -> _eventsState.value = uiStates }
-      } else {
-        val uiStates =
-            events.mapIndexed { index, event ->
-              event.toUIState(
-                  userRepository.getUser(event.creator),
-                  creatorId = event.creator,
-                  index = index,
-                  joined = event.participants.contains(storedUid),
-                  isPrivate = event.isPrivate)
-            }
-        _eventsState.value = uiStates
-      }
+      _eventsState.value =
+          events.mapIndexed { index, event ->
+            event.toUIState(
+                index = index,
+                joined = event.participants.contains(storedUid),
+                isPrivate = event.isPrivate)
+          }
     }
   }
 
@@ -252,15 +156,11 @@ class EventViewModel(
   /**
    * Converts an [Event] into an [EventUIState].
    *
-   * @param user The creator of the event.
-   * @param creatorId The unique identifier of the event creator.
    * @param index The index of the event in the list.
    * @param joined Whether the current user has joined the event.
    * @param isPrivate Whether the event is private..
    */
   private fun Event.toUIState(
-      user: UserProfile?,
-      creatorId: String,
       index: Int = 0,
       joined: Boolean = false,
       isPrivate: Boolean = false
@@ -271,8 +171,7 @@ class EventViewModel(
         description = description ?: "",
         date = date,
         tags = tags.toList(),
-        creator = user?.let { "${it.firstName} ${it.lastName}" } ?: "Unknown",
-        creatorId = creatorId,
+        creator = creator,
         participants = participants.size,
         location = location,
         isPrivate = isPrivate,

--- a/app/src/main/java/com/android/universe/ui/profile/UserProfileScreen.kt
+++ b/app/src/main/java/com/android/universe/ui/profile/UserProfileScreen.kt
@@ -465,7 +465,7 @@ fun ProfileEventList(
                       onChatNavigate = onChatNavigate,
                       onCardClick = onCardClick,
                       onEditButtonClick = onEditButtonClick,
-                      isUserOwner = eventUIState.creatorId == uid,
+                      isUserOwner = eventUIState.creator == uid,
                       showActions = follower != true)
                 }
           }

--- a/app/src/main/java/com/android/universe/ui/profile/UserProfileViewModel.kt
+++ b/app/src/main/java/com/android/universe/ui/profile/UserProfileViewModel.kt
@@ -108,21 +108,13 @@ class UserProfileViewModel(
       val (incoming, history) = rawEvents.partition { event -> event.date.isAfter(now) }
 
       fun mapToUIState(event: Event): EventUIState {
-        val creatorName =
-            if (event.creator == _userState.value.userProfile.uid) {
-              "${_userState.value.userProfile.firstName} ${_userState.value.userProfile.lastName}"
-            } else {
-              "Unknown"
-            }
-
         return EventUIState(
             id = event.id,
             title = event.title,
             description = event.description ?: "",
             date = event.date,
             tags = event.tags.toList(),
-            creator = creatorName,
-            creatorId = event.creator,
+            creator = event.creator,
             participants = event.participants.size,
             location = event.location,
             isPrivate = event.isPrivate,

--- a/app/src/test/java/com/android/universe/ui/event/EventScreenTest.kt
+++ b/app/src/test/java/com/android/universe/ui/event/EventScreenTest.kt
@@ -57,7 +57,7 @@ class EventScreenTest {
       sampleUsers.forEach { fakeUserRepository.addUser(it) }
     }
 
-    viewModel = EventViewModel(fakeEventRepository, null, fakeUserRepository)
+    viewModel = EventViewModel(fakeEventRepository, fakeUserRepository)
 
     composeTestRule.setContentWithStubBackdrop { EventScreen(viewModel = viewModel) }
 

--- a/app/src/test/java/com/android/universe/ui/event/EventViewModelTest.kt
+++ b/app/src/test/java/com/android/universe/ui/event/EventViewModelTest.kt
@@ -108,7 +108,7 @@ class EventViewModelTest {
       sampleUsers.forEach { userRepo.addUser(it) }
     }
 
-    viewModel = EventViewModel(repository, null, userRepo)
+    viewModel = EventViewModel(repository, userRepo)
     viewModel.storedUid = sampleUsers[0].uid
     runTest {
       viewModel.loadEvents()
@@ -130,7 +130,7 @@ class EventViewModelTest {
         "Join us for a casual 5km run around the lake followed by coffee.", firstEvent.description)
     assertEquals(futureDate, firstEvent.date)
     assertEquals(listOf(Tag.SCULPTURE, Tag.COUNTRY), firstEvent.tags)
-    assertEquals("Alice Smith", firstEvent.creator)
+    assertEquals(sampleUsers[0].uid, firstEvent.creator)
     assertEquals(2, firstEvent.participants)
     assertArrayEquals(
         ByteArray(126 * 126) { index -> (index % 256).toByte() }, firstEvent.eventPicture)
@@ -149,12 +149,6 @@ class EventViewModelTest {
 
     val hackathonEvent = viewModel.eventsState.value.first { it.title == "Tech Hackathon 2025" }
     assertEquals(0, hackathonEvent.participants)
-  }
-
-  @Test
-  fun creatorIsFormattedCorrectly() = runTest {
-    val runEvent = viewModel.eventsState.value.first { it.title == "Morning Run at the Lake" }
-    assertEquals("Alice Smith", runEvent.creator)
   }
 
   @Test


### PR DESCRIPTION
## Description
This pull request simplifies and streamlines how event creator information is handled throughout the codebase. The main change is that the `creator` field in events now always stores the creator's unique user ID (UID), rather than sometimes using a display name. This affects how ownership checks and UI display logic work, and removes the need for extra user profile lookups or formatting in several places.

## Changes
- The `creator` field in the `EventUIState` data class now consistently stores the creator's UID, and the `creatorId` field has been removed. All logic that checks event ownership (such as `isUserOwner`) now compares UIDs directly. [
- The `EventViewModel` and related UI code no longer attempt to format or fetch the creator's display name for each event; instead, they use the UID directly for all checks and display. 
- All code and documentation related to the now-unused `UserReactiveRepository` and real-time user profile updates have been removed from `EventViewModel`, including constructor arguments, doc comments, and import statements. 

<img width="300" alt="image" src="https://github.com/user-attachments/assets/6d21b167-12f9-4be1-9603-2319bfe21519" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/8c1b91fc-c4ae-4c6a-912a-b8563ace3fe6" />

Closes #377 

> This description was rewritten using AI